### PR TITLE
fix(dep): explicitly defined shelljs as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "minimatch": "^3.0.4",
     "q": "^1.5.0",
     "request": "^2.81.0",
-    "yeoman-generator": "^1.1.1"
+    "yeoman-generator": "^1.1.1",
+    "shelljs": "^0.7.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
`Shelljs` is used, but not explicitly defined as a dependency in `package.json`. This is fine for newer versions of npm because of deduplication, but breaks for node4. This PR fixes this by explicitly defining shelljs.