### PR TITLE
fix: remove pipline.yml.partial

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,23 @@
 [img-codacy]: https://api.codacy.com/project/badge/Grade/<enter-project-id>?branch=master
 [url-codacy]: https://www.codacy.com/app/ibm-developer/generator-ibm-usecase-enablement
 
+## Introduction
+
+This generator produces content from another source such as a Git repository. Also, existing files that already exist in the destination directory can be extended via [partial files](#partial_files). The folder structure for the source repository should be like the following.
+
+```
+  src
+  ├── java-liberty
+  ├── java-spring
+  ├── node-express
+  ├── public
+  ├── python-flask
+  └── swift-kitura
+```
+
+* Files are seperated by each language folder except public which is shared across all langauges. Currently, supported languages are `java-liberty`, `java-spring`, `node-express`, `python-flask` and `swift-kitura`
+
+
 ## Pre-requisites
 
 Install [Yeoman](http://yeoman.io)
@@ -44,7 +61,30 @@ npm install -g generator-ibm-usecase-enablement
 ## Usage
 
 Following command line arguments are supported
-* `--bluemix {stringified-json}` -  used by Scaffolder to supply project information from `pman`. For an example of a bluemix.json look at the [fallback_bluemix.js](./generators/app/fallback_bluemix.js) file.
+* `--bluemix {stringified-json}` -  used by  an intermal microservice  to supply project information. For an example of a bluemix.json look at the [fallback_bluemix.js](./generators/app/fallback_bluemix.js) file.
+
+<a name="partial_files"></a>
+### Partial Files
+
+Partial files such as *manifest.yml.partial* allows files to be extended if the file exist in the destination directory. For example, if a `package.jsn` file already exists it will add onto using `package.json.partial`.
+
+
+The following partial file(s) are supported with examples.
+
+* [manifest.yml.partial](./generators/init/templates/src/node-express/manifest.yml.partial)
+* [package.json.partial](./generators/init/templates/src/node-express/package.json.partial)
+* [.gitignore.partial](./generators/init/templates/src/node-express/.gitignore.partial)
+* [requirements.txt.partial](./generators/init/templates/src/python-flask/requirements.txt.partial)
+* [Package.swift.partial](./generators/init/templates/src/swift-kitura/Package.swift.partial)
+
+### Replacement Files
+
+Replacement files are similar to partial files except that content is replaced instead of extended. The replacement files contains a single array of JSON objects. Each object has two key-value pairs: `find` and `replace`.
+The `find` key-value will search for any string that matches the exact substring and `replace` key-value will replace the content.
+
+The following replacement file(s) are supported with examples.
+
+* [Dockerfile.replacement](./generators/init/templates/src/node-express/Dockerfile.replacement)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ npm install -g generator-ibm-usecase-enablement
 ## Usage
 
 Following command line arguments are supported
-* `--bluemix {stringified-json}` -  used by  an intermal microservice  to supply project information. For an example of a bluemix.json look at the [fallback_bluemix.js](./generators/app/fallback_bluemix.js) file.
+* `--bluemix {stringified-json}` -  used by  an internal microservice  to supply project information. For an example of a bluemix.json look at the [fallback_bluemix.js](./generators/app/fallback_bluemix.js) file.
 
 <a name="partial_files"></a>
 ### Partial Files
 
-Partial files such as *manifest.yml.partial* allows files to be extended if the file exist in the destination directory. For example, if a `package.jsn` file already exists it will add onto using `package.json.partial`.
+Partial files such as *manifest.yml.partial* allows files to be extended if the file exist in the destination directory. For example, if a `package.json` file already exists it will add onto using `package.json.partial`.
 
 
 The following partial file(s) are supported with examples.

--- a/generators/init/templates/src/node-express/manifest.yml.partial
+++ b/generators/init/templates/src/node-express/manifest.yml.partial
@@ -1,6 +1,5 @@
----
 applications:
-  - disk_quota: 1024M
-    name: example
-    domain: mybluemix.net
-    command: npm prune --production && NODE_ENV=production npm start
+  - command: npm prune --production && NODE_ENV=production npm start
+    disk_quota: 1024M
+    env:
+      NPM_CONFIG_PRODUCTION: false

--- a/generators/language-node-express/index.js
+++ b/generators/language-node-express/index.js
@@ -67,16 +67,6 @@ module.exports = class extends Generator {
 			}
 		}
 
-		// Process pipeline.yaml.partial
-		let srcPipelineYamlPartialPath = srcNodePath + "/.bluemix/pipeline.yml.partial";
-		if (this.fs.exists(srcPipelineYamlPartialPath)) {
-			try {
-				this._addOverrideYaml(yaml.safeLoad(this.fs.read(srcPipelineYamlPartialPath)), "./.bluemix/pipeline.yml");
-			} catch (e) {
-				logger.error("Failed to parse pipeline.yml.partial: " + e);
-			}
-		}
-
 		// Process .gitignore.partial
 		let srcGitIgnorePartialPath = srcNodePath + "/.gitignore.partial";
 		let dstGitIgnorePath = dstRoot + "/.gitignore";

--- a/test/language-node-express/generator-test.js
+++ b/test/language-node-express/generator-test.js
@@ -14,7 +14,6 @@ const HTML_PATH = path.join(GENERATORS_PATH, 'init', 'templates', 'src', 'public
 const GIT_IGNORE_PARTIAL_PATH = path.join(GENERATORS_PATH, 'init', 'templates', 'src', 'node-express', '.gitignore.partial');
 const PACKAGE_JSON_PARTIAL_PATH = path.join(GENERATORS_PATH, 'init', 'templates', 'src', 'node-express', 'package.json.partial');
 const MANIFEST_YAML_PARTIAL_PATH = path.join(GENERATORS_PATH, 'init', 'templates', 'src', 'node-express', 'manifest.yml.partial');
-const PIPELINE_YAML_PARTIAL_PATH = path.join(GENERATORS_PATH, 'init', 'templates', 'src', 'node-express', '.bluemix', 'pipeline.yml.partial');
 const USECASE_ROUTER_PATH = path.join(GENERATORS_PATH, 'init', 'templates', 'src', 'node-express', 'server', 'routers', 'usecase-router.js');
 
 let options;
@@ -63,10 +62,10 @@ describe('generator-usecase-enablement:language-node-express', function () {
 				assert.fileContent('.gitignore', fs.readFileSync(GIT_IGNORE_PARTIAL_PATH, 'utf8'));
 				assert.fileContent('manifest.yml', 'disk_quota: 1024M');
 				assert.fileContent('manifest.yml', 'command: npm prune --production && NODE_ENV=production npm start');
+				assert.fileContent('manifest.yml', 'NPM_CONFIG_PRODUCTION: false');
 				assert.fileContent('manifest.yml', 'timeout: 180');
 				assert.jsonFileContent('package.json', JSON.parse(fs.readFileSync(PACKAGE_JSON_PARTIAL_PATH, 'utf8')));
 				assert.fileContent('public/index.html', fs.readFileSync(HTML_PATH, 'utf8'));
-				assert.fileContent('.bluemix/pipeline.yml', fs.readFileSync(PIPELINE_YAML_PARTIAL_PATH, 'utf8'));
 				assert.fileContent('server/routers/usecase-router.js', fs.readFileSync(USECASE_ROUTER_PATH, 'utf8'));
 				assert.fileContent('Dockerfile', 'npm run build;');
 			});

--- a/test/language-node-express/resources/manifest.yml
+++ b/test/language-node-express/resources/manifest.yml
@@ -6,5 +6,3 @@ applications:
     buildpack: sdk-for-nodejs
     command: npm start
     random-route: true
-    env:
-      NPM_CONFIG_PRODUCTION: false


### PR DESCRIPTION
After speaking with @jkingoliver it would be better to remove the `pipeline.yml.partial` since we don't know how the changes that a user makes can effect deployment. 

* Added description explaining how to use partial and replacement files.
* Briefly explain folder/file structure to use generator-ibm-usecase-enablement
* Remove reference to internal microservices in README