### PR TITLE
fix(java generator): fixes bug in java generator where shared folder wasn't being added to classpath

### DIFF
--- a/generators/language-java/index.js
+++ b/generators/language-java/index.js
@@ -56,10 +56,11 @@ module.exports = class extends Generator {
 		const srcSharedPath = srcRoot + '/shared';
 
 		const dstRoot = this.destinationPath();
-		const dstSharedPath = dstRoot;
+		let dstSharedPath = path.join(dstRoot, 'src','main','webapp');;
 		let dstPublicPath = path.join(dstRoot, 'src','main','webapp');
 		if (this.context.language !== 'java-liberty') {
 			dstPublicPath = path.join(dstRoot, 'src', 'main', 'resources', 'static');
+			dstSharedPath = path.join(dstRoot, 'src', 'main', 'resources');
 		}
 
 		// Copy /src/shared


### PR DESCRIPTION
In a past commit; the shared folder was added to the generated code (where people could put shared resources). However, the location was incorrect and it was formerly not added in a location where it was accessible within the classpath. This fixes that issue